### PR TITLE
Change the sunlight DoomEdNum to 9890, to prevent clash with PointLightStatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ thing // LightProbe (light sampling point for actors)
 
 thing // Sunlight (sunlight properties for the map)
 {
-	type = 9876;
+	type = 9890;
 	suncolor = &lt;int&gt; (color)
 	sundirx = &lt;float&gt; (X direction for the sun)
 	sundiry = &lt;float&gt; (Y direction for the sun)

--- a/src/level/level_light.cpp
+++ b/src/level/level_light.cpp
@@ -91,7 +91,7 @@ void FLevel::SetupLights()
 		{
 			ThingLightProbes.Push(i);
 		}
-		else if (thing->type == 9876) // Sunlight
+		else if (thing->type == 9890) // Sunlight
 		{
 			uint32_t lightcolor = 0xffffff;
 			Vec3 sundir(0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
On the engine side, in my work branch, [I have defined some new dedicated actors](https://github.com/nashmuhandes/gzdoom/commit/70b72a2157019b8686be171a43e3644f769d0110#diff-6268ade0625d139f273e851aa4747a6efe39480845744b5184319bb9cca986ebR140) to act as the stand-ins for static point and spotlights.

Some of the reasons of allocating new actors for this is

- They can be given unique sprite icons which will be useful in UDB
- I wrote a UDBScript that converts dynamic lights into static lights - turning the former into the latter by changing their thing type number
- Generally tidier and more "proper" to have dedicated things for the static light

When choosing the DoomEdNums for `PointLightStatic` and `SpotLightStatic`, I left "holes" in the DoomEdNum list in case the other light types (like the flickering or pulsating ones) would get added as bake-able lights in future. Using the same logic, I left a few more holes in the number list and arrived at 9890 for the sunlight.

![image](https://user-images.githubusercontent.com/4926156/135964495-4b9dd9f7-5e6a-48b3-9588-1e1e763c5401.png)
