### PR TITLE
For static light things, have ZDRay use args instead of UDMF keys. Th…

### DIFF
--- a/src/level/doomdata.h
+++ b/src/level/doomdata.h
@@ -260,6 +260,11 @@ struct FloatVertex
 	float y;
 };
 
+#define THING_POINTLIGHT_STATIC	9876
+#define THING_SPOTLIGHT_STATIC	9881
+#define THING_LIGHTPROBE		9875
+#define THING_ZDRAYINFO			9890
+
 struct ThingLight
 {
 	IntThing        *mapThing;


### PR DESCRIPTION
…is aligns them with dynamic lights, and will help with UDB integration.

Only 'lightintensity' remains as a UDMF key, because there is no more free arg slots for it.

Also made constants for the various thing types to reduce coding mistakes.