### PR TITLE
Customizable sampling distance per surface

### DIFF
--- a/src/level/doomdata.h
+++ b/src/level/doomdata.h
@@ -60,6 +60,15 @@ struct IntSideDef
 
 	IntLineDef *line;
 
+	int sampleDistance;
+	int sampleDistanceTop;
+	int sampleDistanceMiddle;
+	int sampleDistanceBottom;
+
+	inline int GetSampleDistanceTop() const { return sampleDistanceTop ? sampleDistanceTop : sampleDistance; }
+	inline int GetSampleDistanceMiddle() const { return sampleDistanceMiddle ? sampleDistanceMiddle : sampleDistance; }
+	inline int GetSampleDistanceBottom() const { return sampleDistanceBottom ? sampleDistanceBottom : sampleDistance; }
+
 	TArray<UDMFKey> props;
 };
 
@@ -118,6 +127,9 @@ struct IntSector
 
 	Plane ceilingplane;
 	Plane floorplane;
+
+	int sampleDistanceCeiling;
+	int sampleDistanceFloor;
 
 	int floorlightdef;
 	int ceilinglightdef;
@@ -396,7 +408,7 @@ struct FLevel
 
 	vec3 defaultSunColor;
 	vec3 defaultSunDirection;
-	int Samples;
+	int DefaultSamples;
 	int LightBounce;
 	float GridSize;
 

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -694,7 +694,7 @@ void FProcessor::BuildNodes()
 void FProcessor::BuildLightmaps()
 {
 	Level.SetupLights();
-	LightmapMesh = std::make_unique<LevelMesh>(Level, Level.Samples, LMDims);
+	LightmapMesh = std::make_unique<LevelMesh>(Level, Level.DefaultSamples, LMDims);
 
 	std::unique_ptr<GPURaytracer> gpuraytracer;
 	if (!CPURaytrace)

--- a/src/level/level_light.cpp
+++ b/src/level/level_light.cpp
@@ -87,7 +87,7 @@ void FLevel::SetupLights()
 	// GG to whoever memset'ed FLevel
 	defaultSunColor = vec3(1, 1, 1);
 	defaultSunDirection = vec3(0.45f, 0.3f, 0.9f);
-	Samples = 8;
+	DefaultSamples = 8;
 	LightBounce = 0;
 	GridSize = 32.0f;
 
@@ -128,10 +128,10 @@ void FLevel::SetupLights()
 				}
 				else if (!stricmp(key.key, "lm_sampledistance"))
 				{
-					Samples = atoi(key.value);
-					if (Samples < 8) Samples = 8;
-					if (Samples > 128) Samples = 128;
-					Samples = Math::RoundPowerOfTwo(Samples);
+					DefaultSamples = atoi(key.value);
+					if (DefaultSamples < 8) DefaultSamples = 8;
+					if (DefaultSamples > 128) DefaultSamples = 128;
+					DefaultSamples = Math::RoundPowerOfTwo(DefaultSamples);
 				}
 				/*
 				// light bounces temporarily disabled

--- a/src/level/level_udmf.cpp
+++ b/src/level/level_udmf.cpp
@@ -365,6 +365,10 @@ void FProcessor::ParseSidedef(IntSideDef *sd)
 	sd->midtexture[1] = 0;
 	sd->bottomtexture[0] = '-';
 	sd->bottomtexture[1] = 0;
+	sd->sampleDistance = 0;
+	sd->sampleDistanceTop = 0;
+	sd->sampleDistanceMiddle = 0;
+	sd->sampleDistanceBottom = 0;
 	while (!SC_CheckString("}"))
 	{
 		const char *value;
@@ -396,6 +400,22 @@ void FProcessor::ParseSidedef(IntSideDef *sd)
 		{
 			sd->rowoffset = CheckInt(key);
 		}
+		else if (stricmp(key, "lm_sampledist") == 0)
+		{
+			sd->sampleDistance = CheckInt(key);
+		}
+		else if (stricmp(key, "lm_sampledist_top") == 0)
+		{
+			sd->sampleDistanceTop = CheckInt(key);
+		}
+		else if (stricmp(key, "lm_sampledist_mid") == 0)
+		{
+			sd->sampleDistanceMiddle = CheckInt(key);
+		}
+		else if (stricmp(key, "lm_sampledist_bot") == 0)
+		{
+			sd->sampleDistanceBottom = CheckInt(key);
+		}
 
 		// now store the key in its unprocessed form
 		UDMFKey k = {key, value};
@@ -414,6 +434,8 @@ void FProcessor::ParseSector(IntSector *sec)
 	std::vector<int> moreids;
 	memset(&sec->data, 0, sizeof(sec->data));
 	sec->data.lightlevel = 160;
+	sec->sampleDistanceCeiling = 0;
+	sec->sampleDistanceFloor = 0;
 
 	int ceilingplane = 0, floorplane = 0;
 
@@ -513,6 +535,14 @@ void FProcessor::ParseSector(IntSector *sec)
 				}
 				free(workstring);
 			}
+		}
+		else if (stricmp(key, "lm_sampledist_floor") == 0)
+		{
+			sec->sampleDistanceFloor = CheckInt(key);
+		}
+		else if (stricmp(key, "lm_sampledist_ceiling") == 0)
+		{
+			sec->sampleDistanceCeiling = CheckInt(key);
 		}
 
 		// now store the key in its unprocessed form

--- a/src/lightmap/cpuraytracer.cpp
+++ b/src/lightmap/cpuraytracer.cpp
@@ -87,7 +87,6 @@ void CPURaytracer::RaytraceTask(const CPUTraceTask& task)
 		state.StartSurface = nullptr;
 	}
 
-	state.SampleDistance = (float)mesh->samples;
 	state.LightCount = mesh->map->ThingLights.Size();
 	state.SunDir = mesh->map->GetSunDirection();
 	state.SunColor = mesh->map->GetSunColor();
@@ -260,7 +259,7 @@ void CPURaytracer::RunLightTrace(CPUTraceState& state)
 
 			for (uint32_t i = 0; i < state.SampleCount; i++)
 			{
-				vec2 offset = (Hammersley(i, state.SampleCount) - 0.5f) * state.SampleDistance;
+				vec2 offset = (Hammersley(i, state.SampleCount) - 0.5f) * float(surface->sampleDimension);
 				vec3 origin2 = origin + e0 * offset.x + e1 * offset.y;
 
 				vec3 start = origin2;
@@ -316,7 +315,7 @@ void CPURaytracer::RunLightTrace(CPUTraceState& state)
 					e0 = cross(normal, e1);
 					for (uint32_t i = 0; i < state.SampleCount; i++)
 					{
-						vec2 offset = (Hammersley(i, state.SampleCount) - 0.5f) * state.SampleDistance;
+						vec2 offset = (Hammersley(i, state.SampleCount) - 0.5f) * float(surface->sampleDimension);
 						vec3 origin2 = origin + e0 * offset.x + e1 * offset.y;
 
 						LevelTraceHit hit = Trace(origin2, light.Origin);

--- a/src/lightmap/cpuraytracer.h
+++ b/src/lightmap/cpuraytracer.h
@@ -29,7 +29,6 @@ struct CPUTraceState
 	uint32_t PassType;
 	uint32_t LightCount;
 	vec3 SunDir;
-	float SampleDistance;
 	vec3 SunColor;
 	float SunIntensity;
 	vec3 HemisphereVec;

--- a/src/lightmap/glsl_rchit_ambient.h
+++ b/src/lightmap/glsl_rchit_ambient.h
@@ -17,7 +17,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 layout(location = 0) rayPayloadInEXT hitPayload payload;

--- a/src/lightmap/glsl_rchit_bounce.h
+++ b/src/lightmap/glsl_rchit_bounce.h
@@ -17,7 +17,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 layout(location = 0) rayPayloadInEXT hitPayload payload;

--- a/src/lightmap/glsl_rchit_light.h
+++ b/src/lightmap/glsl_rchit_light.h
@@ -17,7 +17,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 layout(location = 0) rayPayloadInEXT hitPayload payload;

--- a/src/lightmap/glsl_rchit_sun.h
+++ b/src/lightmap/glsl_rchit_sun.h
@@ -17,7 +17,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 layout(location = 0) rayPayloadInEXT hitPayload payload;

--- a/src/lightmap/glsl_rgen_ambient.h
+++ b/src/lightmap/glsl_rgen_ambient.h
@@ -24,11 +24,11 @@ layout(set = 0, binding = 4) uniform Uniforms
 	uint PassType;
 	uint Padding0;
 	vec3 SunDir;
-	float SampleDistance;
+	float Padding1;
 	vec3 SunColor;
 	float SunIntensity;
 	vec3 HemisphereVec;
-	float Padding1;
+	float Padding2;
 };
 
 struct SurfaceInfo
@@ -38,7 +38,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 layout(set = 0, binding = 6) buffer SurfaceBuffer { SurfaceInfo surfaces[]; };

--- a/src/lightmap/glsl_rgen_bounce.h
+++ b/src/lightmap/glsl_rgen_bounce.h
@@ -24,11 +24,11 @@ layout(set = 0, binding = 4) uniform Uniforms
 	uint PassType;
 	uint Padding0;
 	vec3 SunDir;
-	float SampleDistance;
+	float Padding1;
 	vec3 SunColor;
 	float SunIntensity;
 	vec3 HemisphereVec;
-	float Padding1;
+	float Padding2;
 };
 
 struct SurfaceInfo
@@ -38,7 +38,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 layout(set = 0, binding = 6) buffer SurfaceBuffer { SurfaceInfo surfaces[]; };

--- a/src/lightmap/glsl_rgen_light.h
+++ b/src/lightmap/glsl_rgen_light.h
@@ -24,11 +24,11 @@ layout(set = 0, binding = 4) uniform Uniforms
 	uint PassType;
 	uint Padding0;
 	vec3 SunDir;
-	float SampleDistance;
+	float Padding1;
 	vec3 SunColor;
 	float SunIntensity;
 	vec3 HemisphereVec;
-	float Padding1;
+	float Padding2;
 };
 
 struct SurfaceInfo
@@ -38,7 +38,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 struct LightInfo
@@ -100,7 +101,7 @@ void main()
 
 			for (uint i = 0; i < SampleCount; i++)
 			{
-				vec2 offset = (Hammersley(i, SampleCount) - 0.5) * SampleDistance;
+				vec2 offset = (Hammersley(i, SampleCount) - 0.5) * surfaces[surfaceIndex].SamplingDistance;
 				vec3 origin2 = origin + offset.x * e0 + offset.y * e1;
 
 				traceRayEXT(acc, gl_RayFlagsOpaqueEXT, 0xff, 2, 0, 2, origin2, minDistance, SunDir, dist, 0);
@@ -151,7 +152,7 @@ void main()
 					e0 = cross(normal, e1);
 					for (uint i = 0; i < SampleCount; i++)
 					{
-						vec2 offset = (Hammersley(i, SampleCount) - 0.5) * SampleDistance;
+						vec2 offset = (Hammersley(i, SampleCount) - 0.5) * surfaces[surfaceIndex].SamplingDistance;
 						vec3 origin2 = origin + offset.x * e0 + offset.y * e1;
 
 						float dist2 = distance(light.Origin, origin2);

--- a/src/lightmap/gpuraytracer.cpp
+++ b/src/lightmap/gpuraytracer.cpp
@@ -103,7 +103,6 @@ void GPURaytracer::Raytrace(LevelMesh* level)
 			BeginTracing();
 
 			Uniforms uniforms = {};
-			uniforms.SampleDistance = (float)mesh->samples;
 			uniforms.SunDir = mesh->map->GetSunDirection();
 			uniforms.SunColor = mesh->map->GetSunColor();
 			uniforms.SunIntensity = 1.0f;
@@ -403,6 +402,8 @@ void GPURaytracer::CreateVertexAndIndexBuffers()
 			info.EmissiveIntensity = 0.0f;
 			info.EmissiveColor = vec3(0.0f, 0.0f, 0.0f);
 		}
+
+		info.SamplingDistance = surface->sampleDimension;
 		surfaces.push_back(info);
 	}
 

--- a/src/lightmap/gpuraytracer.h
+++ b/src/lightmap/gpuraytracer.h
@@ -13,11 +13,11 @@ struct Uniforms
 	uint32_t PassType;
 	uint32_t Padding0;
 	vec3 SunDir;
-	float SampleDistance;
+	float Padding1;
 	vec3 SunColor;
 	float SunIntensity;
 	vec3 HemisphereVec;
-	float Padding1;
+	float Padding2;
 };
 
 struct PushConstants
@@ -34,7 +34,8 @@ struct SurfaceInfo
 	vec3 EmissiveColor;
 	float EmissiveIntensity;
 	float Sky;
-	float Padding0, Padding1, Padding2;
+	float SamplingDistance;
+	float Padding1, Padding2;
 };
 
 struct LightInfo

--- a/src/lightmap/levelmesh.h
+++ b/src/lightmap/levelmesh.h
@@ -74,6 +74,7 @@ struct Surface
 	bool bSky;
 	std::vector<vec2> uvs;
 	std::string material;
+	int sampleDimension;
 };
 
 class LightProbeSample
@@ -99,7 +100,7 @@ public:
 
 	std::vector<std::unique_ptr<LightmapTexture>> textures;
 
-	int samples = 16;
+	int defaultSamples = 16;
 	int textureWidth = 128;
 	int textureHeight = 128;
 


### PR DESCRIPTION
Adds UDMF sidedef properties:

`lm_sampledist`
`lm_sampledist_top`
`lm_sampledist_mid`
`lm_sampledist_bot`

and sector properties:
`lm_sampledist_floor`
`lm_sampledist_ceiling`

Tested both CPU and GPU raytracing


Edit: refactoring completed, fixed couple of mistakes.