### PR TITLE
Add --dump-mesh option and improve LevelMesh::Export

### DIFF
--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -794,6 +794,18 @@ void FProcessor::BuildLightmaps()
 	LightmapMesh->CreateTextures();
 }
 
+void FProcessor::DumpMesh()
+{
+	if (LightmapMesh)
+	{
+		LightmapMesh->Export("levelmesh.obj");
+	}
+	else
+	{
+		printf("Error: no mesh to export\n");
+	}
+}
+
 void FProcessor::Write (FWadWriter &out)
 {
 	if (Level.NumLines() == 0 || Level.NumSides() == 0 || Level.NumSectors() == 0 || Level.NumVertices == 0)

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -59,6 +59,8 @@ public:
 	void BuildLightmaps();
 	void Write(FWadWriter &out);
 
+	void DumpMesh();
+
 private:
 	void LoadUDMF();
 	void LoadThings();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,7 @@ int				 NumThreads = 0;
 int				 LMDims = 1024;
 bool			 CPURaytrace = false;
 bool			 VKDebug = false;
+bool			 DumpMesh = false;
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 
@@ -155,10 +156,11 @@ static option long_opts[] =
 	{"size",			required_argument,	0,	'S'},
 	{"cpu-raytrace",	no_argument,		0,	'C'},
 	{"vkdebug",			no_argument,		0,	'D'},
+	{"dump-mesh",		no_argument,		0,	1004},
 	{0,0,0,0}
 };
 
-static const char short_opts[] = "wVgGvbNrReEm:o:f:p:s:d:PqtzZXx5cj:S:CD";
+static const char short_opts[] = "wVgGvbNrReEm:o:f:p:s:d:PqtzZXx5cj:S:CD:";
 
 // CODE --------------------------------------------------------------------
 
@@ -242,7 +244,14 @@ int main(int argc, char **argv)
 					builder.BuildNodes();
 					builder.BuildLightmaps();
 					builder.Write(outwad);
+
 					END_COUNTER(t2a, t2b, t2c, "   %.3f seconds.\n")
+
+					if(DumpMesh)
+					{
+						printf("\n");
+						builder.DumpMesh();
+					}
 
 					lump = inwad.LumpAfterMap(lump);
 				}
@@ -445,6 +454,9 @@ static void ParseArgs(int argc, char **argv)
 		case 'D':
 			VKDebug = true;
 			break;
+		case 1004:
+			DumpMesh = true;
+			break;
 		case 1000:
 			ShowUsage();
 			exit(0);
@@ -490,6 +502,7 @@ static void ShowUsage()
 		"  -S, --size=NNN           lightmap texture dimensions for width and height must be in powers of two (1, 2, 4, 8, 16, etc)\n"
 		"  -C, --cpu-raytrace       Use the CPU for ray tracing\n"
 		"  -D, --vkdebug            Print messages from the vulkan validation layer\n"
+		"      --dump-mesh          Export level mesh and lightmaps for debugging\n"
 		"  -w, --warn               Show warning messages\n"
 #if HAVE_TIMING
 		"  -t, --no-timing          Suppress timing information\n"


### PR DESCRIPTION
For development/debugging purposes I find it useful to see the mesh.

Known related problem:

Importing the resulting .obj into Blender works out of the box, except for the completely dark areas. I can't get Blender to create a simple pure black color material.
