### PR TITLE
Add --preview switch that significantly reduces sample count

### DIFF
--- a/src/lightmap/cpuraytracer.cpp
+++ b/src/lightmap/cpuraytracer.cpp
@@ -17,6 +17,9 @@
 extern bool VKDebug;
 extern int NumThreads;
 
+extern int coverageSampleCount;
+extern int bounceSampleCount;
+
 CPURaytracer::CPURaytracer()
 {
 }

--- a/src/lightmap/cpuraytracer.h
+++ b/src/lightmap/cpuraytracer.h
@@ -92,9 +92,6 @@ private:
 
 	static void RunJob(int count, std::function<void(int i)> callback);
 
-	const int coverageSampleCount = 256;
-	const int bounceSampleCount = 2048;
-
 	LevelMesh* mesh = nullptr;
 	std::vector<vec3> HemisphereVectors;
 	std::vector<CPULightInfo> Lights;

--- a/src/lightmap/gpuraytracer.cpp
+++ b/src/lightmap/gpuraytracer.cpp
@@ -29,6 +29,10 @@
 
 extern bool VKDebug;
 
+extern int coverageSampleCount;
+extern int bounceSampleCount;
+extern int ambientSampleCount;
+
 GPURaytracer::GPURaytracer()
 {
 	device = std::make_unique<VulkanDevice>(0, VKDebug);

--- a/src/lightmap/gpuraytracer.h
+++ b/src/lightmap/gpuraytracer.h
@@ -90,9 +90,6 @@ private:
 	static float RadicalInverse_VdC(uint32_t bits);
 	static vec2 Hammersley(uint32_t i, uint32_t N);
 
-	const int coverageSampleCount = 256;
-	const int bounceSampleCount = 2048;
-	const int ambientSampleCount = 2048;
 	int rayTraceImageSize = 1024;
 
 	LevelMesh* mesh = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,10 @@ bool			 CPURaytrace = false;
 bool			 VKDebug = false;
 bool			 DumpMesh = false;
 
+int coverageSampleCount = 256;
+int bounceSampleCount = 2048;
+int ambientSampleCount = 2048;
+
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 
 static option long_opts[] =
@@ -157,10 +161,11 @@ static option long_opts[] =
 	{"cpu-raytrace",	no_argument,		0,	'C'},
 	{"vkdebug",			no_argument,		0,	'D'},
 	{"dump-mesh",		no_argument,		0,	1004},
+	{"preview",			no_argument,		0,	1005},
 	{0,0,0,0}
 };
 
-static const char short_opts[] = "wVgGvbNrReEm:o:f:p:s:d:PqtzZXx5cj:S:CD:";
+static const char short_opts[] = "wVgGvbNrReEm:o:f:p:s:d:PqtzZXx5cj:S:CD::";
 
 // CODE --------------------------------------------------------------------
 
@@ -456,6 +461,11 @@ static void ParseArgs(int argc, char **argv)
 			break;
 		case 1004:
 			DumpMesh = true;
+			break;
+		case 1005:
+			coverageSampleCount = 4;
+			bounceSampleCount = 16;
+			ambientSampleCount = 16;
 			break;
 		case 1000:
 			ShowUsage();


### PR DESCRIPTION
Speeds up the lightmap building significantly with a barely noticable drop in quality.